### PR TITLE
Improved aesthetic settings

### DIFF
--- a/assets/custom.scss
+++ b/assets/custom.scss
@@ -1,0 +1,9 @@
+/* Ajout d'améliorations de style personnalisées */
+body {
+  background-color: #F5FAFE;
+}
+
+img {
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,8 @@
 baseURL = "https://alexandrecarton.netlify.app/"
 title = "Alexandre CARTON"
 author = "Alex Carton"
+languageCode = "fr-fr"
+defaultContentLanguage = "fr"
 paginate = 5
 theme = "apero"
 
@@ -20,13 +22,13 @@ theme = "apero"
   # serif options: Fraunces / EB Garamond / Bitter
   # sans-serif options: Commissioner / Atkinson Hyperlegible / Metropolis
   
-  textFontFamily = "Atkinson Hyperlegible"
-  headingFontFamily = "EB Garamond"
+  textFontFamily = "Commissioner"
+  headingFontFamily = "Fraunces"
   customtextFontFamily = ""
   customheadingFontFamily = ""
 
   # Thème de couleur
-  theme = "forest"  # forest, grayscale, peach, plum, poppy, sky, violet, water
+  theme = "sky"  # forest, grayscale, peach, plum, poppy, sky, violet, water
 
   # Icônes sociales
   socialInHeader = true


### PR DESCRIPTION
## Summary
- configure site for French language
- switch to Commissioner/Fraunces fonts
- use the "sky" color theme
- add custom styles for a lighter background and rounded images

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68483a85a880832bbfe7068c72674086