### PR TITLE
Remove theme credits from footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,7 @@ title = "Alexandre CARTON"
 author = "Alex Carton"
 paginate = 5
 theme = "apero"
+copyright = "© 2025 Alexandre Carton, France"
 
 
 [params]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,28 @@
+<footer class="site-footer pv4 bt b--transparent ph5" role="contentinfo">
+  <nav class="db dt-l w-100">
+    <p class="site-copyright f7 db dtc-l v-mid w-100 w-33-l tc tl-l pv2 pv0-l mv0 lh-copy">
+      {{ if ne site.Copyright "" }}{{ site.Copyright | safeHTML }}{{ else }}&copy; {{ now.Format "2006"}}{{ if site.Params.orgName }} {{ site.Params.orgName }}{{ end }}{{ if site.Params.orgLocal }}, {{ site.Params.orgLocal }}{{ end }}{{ end }}
+    </p>
+    {{ if and (not .IsHome) (site.Params.socialInFooter) }}
+    <div class="site-social-links db dtc-l v-mid w-100 w-33-l tc pv2 pv0-l mv0">
+      {{ partial "shared/social-links.html" . }}
+    </div>
+    {{ end }}
+    <div class="site-links f6 db dtc-l v-mid w-100 w-67-l tc tr-l pv2 pv0-l mv0">
+      {{ range site.Menus.footer }}
+      <a class="dib pv1 ph2 link" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+      {{ end }}
+    </div>
+  </nav>
+  {{ with site.Params.math }}
+    {{ partial "shared/math-preprocess.html" }}
+  {{ with .renderer }}
+    {{ if eq . "mathjax" }}
+      {{ partial "shared/math-render-mathjax.html" }}
+    {{ end }}
+    {{ if eq . "katex" }}
+      {{ partial "shared/math-render-katex.html" }}
+    {{ end }}
+  {{ end }}
+  {{ end }}
+</footer>


### PR DESCRIPTION
## Summary
- override footer template to remove theme attribution
- set explicit copyright text

## Testing
- `hugo --cleanDestinationDir -s . -d public`

------
https://chatgpt.com/codex/tasks/task_e_68483d42d494832bbfdaa03cbfbbfdeb